### PR TITLE
Fixup installation success check in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ plugins:
 You can confirm the plugin is correctly installed by running:
 
 ```bash
-serverless | grep "ServerlessOpenAPIDocumentation"
+serverless | grep -i "ServerlessOpenAPIDocumentation"
 ```
 
 It should return `ServerlessOpenAPIDocumentation` as one of the plugins on the list.


### PR DESCRIPTION
In my installation, the plugin was called `ServerlessOpenApiDocumentation` (notice the lowercase `Api`). For maximum compatibility and less confusion, relax `grep`.