### PR TITLE
Fix loading of request models and *params

### DIFF
--- a/src/DefinitionGenerator.ts
+++ b/src/DefinitionGenerator.ts
@@ -148,12 +148,7 @@ export class DefinitionGenerator {
       operationObj.requestBody = this.getRequestBodiesFromConfig(documentationConfig);
     }
 
-    if (documentationConfig.queryParams
-        || documentationConfig.pathParams
-        || documentationConfig.cookieParams
-        || documentationConfig.requestHeaders) {
-      operationObj.parameters = this.getParametersFromConfig(documentationConfig);
-    }
+    operationObj.parameters = this.getParametersFromConfig(documentationConfig);
 
     operationObj.responses = this.getResponsesFromConfig(documentationConfig);
 

--- a/src/DefinitionGenerator.ts
+++ b/src/DefinitionGenerator.ts
@@ -144,11 +144,14 @@ export class DefinitionGenerator {
       operationObj.deprecated = true;
     }
 
-    if (operationObj.requestBody) {
+    if (documentationConfig.requestBody) {
       operationObj.requestBody = this.getRequestBodiesFromConfig(documentationConfig);
     }
 
-    if (operationObj.parameters) {
+    if (documentationConfig.queryParams
+        || documentationConfig.pathParams
+        || documentationConfig.cookieParams
+        || documentationConfig.requestHeaders) {
       operationObj.parameters = this.getParametersFromConfig(documentationConfig);
     }
 


### PR DESCRIPTION
Combining the commits/comments from the two outstanding PRs. Credit to https://github.com/jhaagmans

https://github.com/temando/serverless-openapi-documentation/pull/27
https://github.com/temando/serverless-openapi-documentation/pull/24

I can also confirm that *params and the requestModel properties are being ignored in the serverless.yml configuration. The DefinitionGenerator needs to check for a value in the documentationConfig, not the being-generated operationObj.

This seems to be a regression from 0.3 > 0.4.