### PR TITLE
Fix small bug

### DIFF
--- a/src/DefinitionGenerator.ts
+++ b/src/DefinitionGenerator.ts
@@ -144,11 +144,11 @@ export class DefinitionGenerator {
       operationObj.deprecated = true;
     }
 
-    if (operationObj.requestBody) {
+    if (documentationConfig.requestBody) {
       operationObj.requestBody = this.getRequestBodiesFromConfig(documentationConfig);
     }
 
-    if (operationObj.parameters) {
+    if (documentationConfig.parameters) {
       operationObj.parameters = this.getParametersFromConfig(documentationConfig);
     }
 


### PR DESCRIPTION
- The operation object should build request body and parameters from documentationConfig, hence if documentationConfig has the keys generate operationObj from it