### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/ServerlessOpenApiDocumentation.ts
+++ b/src/ServerlessOpenApiDocumentation.ts
@@ -42,14 +42,17 @@ export class ServerlessOpenApiDocumentation {
               output: {
                 usage: 'Output file location [default: openapi.yml|json]',
                 shortcut: 'o',
+                type: 'string',
               },
               format: {
                 usage: 'OpenAPI file format (yml|json) [default: yml]',
                 shortcut: 'f',
+                type: 'string',
               },
               indent: {
                 usage: 'File indentation in spaces [default: 2]',
                 shortcut: 'i',
+                type: 'string',
               },
             },
           },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessOpenApiDocumentation for "output", "format", "indent"
```