### PR TITLE
Fix requestBody and parameters on requests

### DIFF
--- a/src/DefinitionGenerator.ts
+++ b/src/DefinitionGenerator.ts
@@ -144,11 +144,11 @@ export class DefinitionGenerator {
       operationObj.deprecated = true;
     }
 
-    if (operationObj.requestBody) {
+    if (documentationConfig.requestBody) {
       operationObj.requestBody = this.getRequestBodiesFromConfig(documentationConfig);
     }
 
-    if (operationObj.parameters) {
+    if (documentationConfig.parameters) {
       operationObj.parameters = this.getParametersFromConfig(documentationConfig);
     }
 


### PR DESCRIPTION
When defining a `requestBody` parameter on a route, the output file does not includes the data specified. That's because when processing the data before creating the output file, the variable does not reference the correct attribute where the data should come from.

With this fix, the output file is processed correctly again.